### PR TITLE
Fix session user ID parsing to restore sign-in and sign-up

### DIFF
--- a/server/auth.ts
+++ b/server/auth.ts
@@ -108,9 +108,15 @@ export function setupAuth(app: Express) {
   });
 
   // Deserialize user from session
-  passport.deserializeUser(async (id: number, done) => {
+  passport.deserializeUser(async (id: number | string, done) => {
     try {
-      const user = await storage.getUser(id);
+      // Session stores may return the ID as a string
+      const userId = typeof id === "string" ? parseInt(id, 10) : id;
+      if (Number.isNaN(userId)) {
+        return done(new Error("Invalid user ID"));
+      }
+
+      const user = await storage.getUser(userId);
       done(null, user as any);
     } catch (error) {
       done(error);


### PR DESCRIPTION
## Summary
- ensure user ID from session is converted to a number before lookup

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run check` *(fails: JSX syntax errors in various client files)*

------
https://chatgpt.com/codex/tasks/task_e_68a57a3a88f8832c9641295fe3d5323d