### PR TITLE
Prioritize X-Forwarded-For for client IP detection

### DIFF
--- a/server/security-middleware.ts
+++ b/server/security-middleware.ts
@@ -272,11 +272,17 @@ class SecurityMiddleware {
 
   // Private helper methods
   private getClientIP(req: Request): string {
-    return req.ip || 
-           req.connection.remoteAddress || 
-           req.socket.remoteAddress || 
-           (req.headers['x-forwarded-for'] as string)?.split(',')[0] || 
-           'unknown';
+    const forwarded = req.headers['x-forwarded-for'];
+    if (typeof forwarded === 'string' && forwarded.length > 0) {
+      return forwarded.split(',')[0];
+    }
+
+    return (
+      req.ip ||
+      req.connection.remoteAddress ||
+      req.socket.remoteAddress ||
+      'unknown'
+    );
   }
 
   private handleRateLimit(ip: string, type: 'minute' | 'hour', req: Request) {


### PR DESCRIPTION
- Why:
  - Security middleware relied on proxy/IP fields before checking `x-forwarded-for`, leading to incorrect client addresses in logs and rate limiting
  - Users behind proxies could be misidentified or share rate limits
- What:
  - Prefer the first `x-forwarded-for` value when resolving the client IP
  - Fall back to existing address sources if the header is missing
- How to test:
  - `npm test`
  - `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_68a58789d8f4832cba5bb8b38436dd1e