### PR TITLE
Fix: login/register flow (phase 2)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+SESSION_SECRET=your-session-secret
+DATABASE_URL=postgres://user:pass@localhost:5432/mylinked
+LOG_AUTH=0

--- a/migrations/02-auth-normalization.sql
+++ b/migrations/02-auth-normalization.sql
@@ -1,0 +1,3 @@
+-- Ensure case-insensitive uniqueness for username and email
+CREATE UNIQUE INDEX IF NOT EXISTS users_username_lower_idx ON users (LOWER(username));
+CREATE UNIQUE INDEX IF NOT EXISTS users_email_lower_idx ON users (LOWER(email));

--- a/package.json
+++ b/package.json
@@ -8,7 +8,9 @@
     "build": "vite build && esbuild server/index.ts --platform=node --packages=external --bundle --format=esm --outdir=dist",
     "start": "NODE_ENV=production node dist/index.js",
     "check": "tsc",
-    "db:push": "drizzle-kit push"
+    "db:push": "drizzle-kit push",
+    "test": "tsx --test server/auth.test.ts",
+    "auth:smoke": "tsx scripts/auth-smoke.ts"
   },
   "dependencies": {
     "@hookform/resolvers": "^3.10.0",

--- a/scripts/auth-smoke.ts
+++ b/scripts/auth-smoke.ts
@@ -1,0 +1,39 @@
+import { randomUUID } from 'crypto';
+
+const base = process.env.BASE_URL || 'http://localhost:5000';
+
+async function api(path: string, options: any) {
+  const res = await fetch(base + path, {
+    ...options,
+    headers: { 'Content-Type': 'application/json', ...(options.headers || {}) },
+    credentials: 'include'
+  });
+  const body = await res.json().catch(() => ({}));
+  return { res, body };
+}
+
+(async () => {
+  const id = randomUUID().slice(0, 8);
+  const username = `smoke_${id}`;
+  const password = 'pass123!';
+  const name = 'Smoke Test';
+  const email = `smoke_${id}@example.com`;
+
+  let { res } = await api('/api/register', {
+    method: 'POST',
+    body: JSON.stringify({ username, password, name, email })
+  });
+  console.log('register', res.status);
+
+  ({ res } = await api('/api/login', {
+    method: 'POST',
+    body: JSON.stringify({ username, password })
+  }));
+  console.log('login', res.status);
+
+  ({ res } = await api('/api/register', {
+    method: 'POST',
+    body: JSON.stringify({ username, password, name, email })
+  }));
+  console.log('duplicate', res.status);
+})();

--- a/server/auth.test.ts
+++ b/server/auth.test.ts
@@ -1,0 +1,67 @@
+import express from 'express';
+import { before, after, test } from 'node:test';
+import assert from 'node:assert/strict';
+import { registerRoutes } from './routes';
+
+let app: express.Express;
+let server: any;
+let baseUrl: string;
+let cookie = '';
+
+before(async () => {
+  app = express();
+  await registerRoutes(app);
+  server = app.listen(0);
+  const { port } = server.address() as any;
+  baseUrl = `http://127.0.0.1:${port}`;
+});
+
+after(() => {
+  server?.close();
+});
+
+async function api(path: string, options: any) {
+  const res = await fetch(baseUrl + path, {
+    ...options,
+    headers: { 'Content-Type': 'application/json', ...(options.headers || {}), cookie },
+  });
+  const text = await res.text();
+  let body: any = undefined;
+  try { body = text ? JSON.parse(text) : undefined; } catch {}
+  const setCookie = res.headers.get('set-cookie');
+  if (setCookie) cookie = setCookie;
+  return { res, body };
+}
+
+test('register/login flow', async () => {
+  const username = `test${Date.now()}`;
+  const password = 'secret123';
+  const email = `${username}@example.com`;
+  const name = 'Test User';
+
+  let result = await api('/api/register', {
+    method: 'POST',
+    body: JSON.stringify({ username, password, email, name })
+  });
+  assert.equal(result.res.status, 201);
+  assert.ok(cookie.includes('mylinked.session'));
+
+  result = await api('/api/login', {
+    method: 'POST',
+    body: JSON.stringify({ username, password })
+  });
+  assert.equal(result.res.status, 200);
+  assert.ok(cookie.includes('mylinked.session'));
+
+  result = await api('/api/login', {
+    method: 'POST',
+    body: JSON.stringify({ username, password: 'wrong' })
+  });
+  assert.equal(result.res.status, 401);
+
+  result = await api('/api/register', {
+    method: 'POST',
+    body: JSON.stringify({ username, password, email, name })
+  });
+  assert.equal(result.res.status, 409);
+});

--- a/server/db-storage-enhanced.ts
+++ b/server/db-storage-enhanced.ts
@@ -187,22 +187,28 @@ export class EnhancedDatabaseStorage implements IStorage {
   }
 
   async getUserByUsername(username: string): Promise<User | undefined> {
+    const normalized = username.trim().toLowerCase();
     const [user] = await db
       .select()
       .from(users)
-      .where(eq(users.username, username));
+      .where(eq(users.username, normalized));
     return user;
   }
 
   async getUserByEmail(email: string): Promise<User | undefined> {
+    const normalized = email.trim().toLowerCase();
     const [user] = await db
       .select()
       .from(users)
-      .where(eq(users.email, email));
+      .where(eq(users.email, normalized));
     return user;
   }
 
   async createUser(insertUser: InsertUser): Promise<User> {
+    // Normalize input
+    const username = insertUser.username.trim().toLowerCase();
+    const email = insertUser.email ? insertUser.email.trim().toLowerCase() : undefined;
+
     // Hash the password before inserting
     const password = await this.hashPassword(insertUser.password);
 
@@ -210,6 +216,8 @@ export class EnhancedDatabaseStorage implements IStorage {
       .insert(users)
       .values({
         ...insertUser,
+        username,
+        email,
         password
       })
       .returning();


### PR DESCRIPTION
## Summary
- normalize usernames/emails and tighten session cookies for reliable auth
- gate verbose auth logs behind `LOG_AUTH` and add smoke test script
- add case-insensitive unique indexes for username/email and sample env file

## Testing
- `npm test` *(fails: DATABASE_URL must be set)*
- `npm run check` *(fails: numerous TS errors in existing client files)*
- `npm run auth:smoke` *(fails: fetch ECONNREFUSED localhost:5000)*

------
https://chatgpt.com/codex/tasks/task_e_68a5b6c46d44832ca1501cef52ed1cc6